### PR TITLE
fix(android): java.lang.NullPointerException on resumeAllGainedFocus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,10 @@ Thumbs.db
 
 node_modules
 
-
+#eclipse
+bin
+.project
+.classpath
 
 
 

--- a/src/android/AudioHandler.java
+++ b/src/android/AudioHandler.java
@@ -411,7 +411,7 @@ public class AudioHandler extends CordovaPlugin {
 
     public void resumeAllGainedFocus() {
         for (AudioPlayer audio : this.pausedForFocus) {
-            audio.startPlaying(null);
+            audio.resumePlaying();
         }
         this.pausedForFocus.clear();
     }

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -354,6 +354,13 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
     }
 
     /**
+     * Resume playing.
+     */
+    public void resumePlaying() {
+    	this.startPlaying(this.audioFile);
+    }
+
+    /**
      * Callback to be invoked when playback of a media source has completed.
      *
      * @param player           The MediaPlayer that reached the end of the file
@@ -582,7 +589,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
                     //if we are readying the same file
                     if (this.audioFile.compareTo(file) == 0) {
                         //maybe it was recording?
-                        if(this.recorder!=null && player==null) {
+                        if (player == null) {
                             this.player = new MediaPlayer();
                             this.player.setOnErrorListener(this);
                             this.prepareOnly = false;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
